### PR TITLE
Adding default datetime format

### DIFF
--- a/aws-logs/defaults/main.yml
+++ b/aws-logs/defaults/main.yml
@@ -1,3 +1,5 @@
+---
 watched_logs:
-  - { path: /var/log/messages, datetime_format: "%b %d %H:%M:%S" }
+  - path: /var/log/messages
+
 log_group_name: "{{ name }}"

--- a/aws-logs/templates/awslogs.conf
+++ b/aws-logs/templates/awslogs.conf
@@ -6,7 +6,7 @@ state_file = /var/lib/awslogs/agent-state
 {% for log_stream in watched_logs %}
 
 [{{ log_stream.path }}]
-datetime_format = {{ log_stream.datetime_format }}
+datetime_format = {{ log_stream.datetime_format|default('%Y-%m-%d %H:%M:%S %z') }}
 file = {{ log_stream.path }}
 log_stream_name = {{ log_stream.path }}
 log_group_name = {{ log_group_name }}


### PR DESCRIPTION
Also converting JSON-ish bit to idiomatic YAML syntax.

The suggestion for the `%Y-%m-%d %H:%M:%S %z` format comes from here:

https://github.com/department-of-veterans-affairs/devops/pull/502#discussion_r76079201

I don't have a strong opinion on either option, just that we should pick a single format and stick with it as much as possible.
