### PR TITLE
Remove name variable from generic roles

### DIFF
--- a/centos/tasks/main.yml
+++ b/centos/tasks/main.yml
@@ -54,4 +54,4 @@
               state=present
 
 - name: echo
-  debug: msg="{{ name }} base OS is ready to go!"
+  debug: msg="base OS is ready to go!"

--- a/git/tasks/main.yml
+++ b/git/tasks/main.yml
@@ -8,7 +8,7 @@
     git: "{{ git | combine({ 'key_file': '/tmp/git.pem' }) }}"
   when: git.key_contents is defined
 
-- name: clone git source for {{name}}
+- name: clone git source
   git:
     repo: "{{ git.url }}"
     dest: "{{ dest }}"
@@ -25,8 +25,8 @@
   when: git.key_contents is defined
 
 - name: save git hash
-  set_fact: 
+  set_fact:
     git_hash: "{{repo.after}}"
 
 - name: echo
-  debug: msg="checked out {{name}} {{repo.after}}"
+  debug: msg="checked out {{repo.after}}"

--- a/ruby/tasks/main.yml
+++ b/ruby/tasks/main.yml
@@ -39,4 +39,4 @@
     rbenv_root: "{{rbenv_root}}"
 
 - name: echo
-  debug: msg="{{name}} Ruby env {{ ruby_version }} is ready to go!"
+  debug: msg="Ruby env {{ ruby_version }} is ready to go!"


### PR DESCRIPTION
Remove unnecessary `{{ name }}` input from `git`, `centos`, and `ruby `roles so they're easier to invoke outside of roadrunner. `{{ name }}` was only used in debug message output. 