### PR TITLE
Fixed a bug where ruby_dependencies are not installed.

### DIFF
--- a/ruby/tasks/main.yml
+++ b/ruby/tasks/main.yml
@@ -11,7 +11,6 @@
   yum: name={{item}} state=latest enablerepo=epel
   with_items:
       - "{{default_ruby_dependencies|union(ruby_dependencies|default([]))}}"
-  when: ruby_preinstalled == false
 
 - name: install ruby
   shell: "{{rbenv_root}}/bin/rbenv install {{ruby_version}} -f creates={{rbenv_root}}/versions/{{ruby_version}}/bin/ruby"


### PR DESCRIPTION
The previous change-set mistakenly assume that just because Ruby is installed, it may skip all ruby dependencies. This is wrong because yum dependencies among apps might be different and the base AMI might not cover everything (although it should).