### PR TITLE
Start and enable yum-cron

### DIFF
--- a/centos/tasks/main.yml
+++ b/centos/tasks/main.yml
@@ -36,6 +36,12 @@
 - name: configure yum-cron to automatically apply updates.
   lineinfile: dest=/etc/yum/yum-cron.conf regexp=apply_updates line='apply_updates = yes'
   when: skip_update is undefined
+  
+- name: start yum-cron
+  service:
+    name: yum-cron
+    state: started
+    enabled: yes # start on boot
 
 - name: set ulimit
   copy: src=files/limits.conf dest=/etc/security/limits.conf owner=root group=root force=true


### PR DESCRIPTION
This is a bug -- currently yum-cron was being installed and configured to apply security updates but the service is never enabled. 