### PR TITLE
Added more details to AMI name

### DIFF
--- a/aws-launch/defaults/main.yml
+++ b/aws-launch/defaults/main.yml
@@ -1,5 +1,5 @@
 # default AWS linux
-timestamp: "{{ ansible_date_time.year }}{{ ansible_date_time.month }}{{ ansible_date_time.day }}{{ ansible_date_time.hour }}{{ ansible_date_time.minute }}"
+timestamp: "{{ ansible_date_time.year }}{{ ansible_date_time.month }}{{ ansible_date_time.day }}{{ ansible_date_time.hour }}{{ ansible_date_time.minute }}{{ ansible_date_time.second }}"
 ami_id: ami-d0f506b0
 ami_user: ec2-user
 instance_type: t2.medium

--- a/deploy-to-aws.yml
+++ b/deploy-to-aws.yml
@@ -54,6 +54,7 @@
       playbook_group: "tmp_ami_group"
       user_data: "{{ launch_user_init_script | default(None) or omit }}"
       ami_user: "{{ launch_user | default(None) or omit }}"
+      instance_name: "{{ app_group }}-{{ app_project }}-{{ app_name }}-{{ deploy_env }}_ami-{{ timestamp }}"
 
 - name: deploy application to new instance
   hosts: tmp_ami_group


### PR DESCRIPTION
Added seconds precision to `timestamp` and added environment info to EC2 instance name. This is done to address a bug where concurrent deployment to two different environment may result in AMI naming collision.

Tested on certification deployment, and the EC2 name looks something like this 
`dsva-appeals-certification-dev_ami-20161109112516`