### PR TITLE
Add logrotate role & rotate rails logs by default

### DIFF
--- a/logrotate/.travis.yml
+++ b/logrotate/.travis.yml
@@ -1,0 +1,14 @@
+---
+language: python
+python: "2.7"
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq python-apt python-pycurl
+install:
+  - pip install ansible
+script:
+  - "printf '[defaults]\nroles_path = ../' > ansible.cfg"
+  - ansible-playbook -i tests/inventory --syntax-check tests/test.yml
+  - ansible-playbook -i tests/inventory --connection=local --become -vvvv tests/test.yml
+notifications:
+  email: false

--- a/logrotate/LICENSE
+++ b/logrotate/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2016-14, Nick Hammond
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of ansiblebit nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/logrotate/README.md
+++ b/logrotate/README.md
@@ -1,0 +1,70 @@
+# logrotate
+
+![Build Status](https://travis-ci.org/nickhammond/ansible-logrotate.svg?branch=master)
+
+Installs logrotate and provides an easy way to setup additional logrotate scripts by
+specifying a list of directives.
+
+## Requirements
+
+None
+
+## Role Variables
+
+**logrotate_scripts**: A list of logrotate scripts and the directives to use for the rotation.
+
+* name - The name of the script that goes into /etc/logrotate.d/
+* path - Path to point logrotate to for the log rotation
+* options - List of directives for logrotate, view the logrotate man page for specifics
+* scripts - Dict of scripts for logrotate (see Example below)
+
+```
+logrotate_scripts:
+  - name: rails
+    path: "/srv/current/log/*.log"
+    options:
+      - weekly
+      - size 25M
+      - missingok
+      - compress
+      - delaycompress
+      - copytruncate
+```
+
+## Dependencies
+
+None
+
+## Example Playbook
+
+Setting up logrotate for additional Nginx logs, with postrotate script (assuming this role is located in `roles/logrotate`).
+
+```
+- role: logrotate
+  logrotate_scripts:
+    - name: nginx
+      path: /var/log/nginx/*.log
+      options:
+        - weekly
+        - size 25M
+        - rotate 7
+        - missingok
+        - compress
+        - delaycompress
+        - copytruncate
+      scripts:
+        postrotate: "[ -s /run/nginx.pid ] && kill -USR1 `cat /run/nginx.pid`"
+```
+
+## License
+
+[BSD](https://raw.githubusercontent.com/nickhammond/logrotate/master/LICENSE)
+
+## Author Information
+
+* [nickhammond](https://github.com/nickhammond) | [www](http://www.nickhammond.com) | [twitter](http://twitter.com/nickhammond)
+* [bigjust](https://github.com/bigjust)
+* [steenzout](https://github.com/steenzout)
+* [jeancornic](https://github.com/jeancornic)
+* [duhast](https://github.com/duhast)
+* [kagux](https://github.com/kagux)

--- a/logrotate/defaults/main.yml
+++ b/logrotate/defaults/main.yml
@@ -1,0 +1,2 @@
+logrotate_conf_dir: "/etc/logrotate.d/"
+logrotate_scripts: []

--- a/logrotate/meta/.galaxy_install_info
+++ b/logrotate/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Thu Nov 10 20:08:19 2016', version: master}

--- a/logrotate/meta/main.yml
+++ b/logrotate/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  author: Nick Hammond
+  description: Role to configure logrotate scripts
+  license: BSD
+  min_ansible_version: 1.9
+  platforms:
+  - name: Ubuntu
+    versions:
+    - lucid
+    - precise
+    - trusty
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - system
+dependencies: []

--- a/logrotate/tasks/main.yml
+++ b/logrotate/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: nickhammond.logrotate | Install logrotate
+  package:
+    name: logrotate
+    state: present
+  when: logrotate_scripts is defined and logrotate_scripts|length > 0
+
+- name: nickhammond.logrotate | Setup logrotate.d scripts
+  template:
+    src: logrotate.d.j2
+    dest: "{{ logrotate_conf_dir }}{{ item.name }}"
+  with_items: "{{ logrotate_scripts }}"
+  when: logrotate_scripts is defined

--- a/logrotate/templates/logrotate.d.j2
+++ b/logrotate/templates/logrotate.d.j2
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+
+"{{ item.path }}" {
+  {% if item.options is defined -%}
+  {% for option in item.options -%}
+  {{ option }}
+  {% endfor -%}
+  {% endif %}
+  {%- if item.scripts is defined -%}
+  {%- for name, script in item.scripts.iteritems() -%}
+  {{ name }}
+    {{ script }}
+  endscript
+  {% endfor -%}
+  {% endif -%}
+}

--- a/logrotate/tests/inventory
+++ b/logrotate/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/logrotate/tests/test.yml
+++ b/logrotate/tests/test.yml
@@ -1,0 +1,18 @@
+---
+- hosts: all
+  become: True
+  roles:
+    - ansible-logrotate
+    - role: ansible-logrotate
+      logrotate_scripts:
+        - name: nginx-options
+          path: /var/log/nginx/options.log
+          options:
+            - daily
+
+    - role: ansible-logrotate
+      logrotate_scripts:
+        - name: nginx-scripts
+          path: /var/log/nginx/scripts.log
+          scripts:
+            postrotate: "echo test"

--- a/roadrunner/meta/main.yml
+++ b/roadrunner/meta/main.yml
@@ -17,5 +17,16 @@ dependencies:
     environment_variables: "{{ default_app_environment | combine(app_environment | default({})) }}"
     stdout_redirect: "{{ app_src }}/log/{{ name }}.out"
 
+  - role: logrotate
+    logrotate_scripts:
+      - name: "{{ name }}"
+        path: "{{ app_src }}/log/*"
+        options:
+          - weekly
+          - size 10M
+          - rotate 7
+          - missingok
+          - copytruncate
+
   - role: roadrunner-aws
     when: is_aws is defined


### PR DESCRIPTION
8a9f059478ce39cc481ce0758308c78645f078b8 just imports https://github.com/nickhammond/ansible-logrotate from ansible galaxy 

Fixes #17 

This can help simplify our application logging config by removing all rotating logic. Rotation will become responsibility of the [execution environment](https://12factor.net/logs).