### PR TITLE
Enable  configuration option in aws-logs

### DIFF
--- a/aws-logs/templates/awslogs.conf
+++ b/aws-logs/templates/awslogs.conf
@@ -8,6 +8,6 @@ state_file = /var/lib/awslogs/agent-state
 [{{ log_stream.path }}]
 datetime_format = {{ log_stream.datetime_format|default('%Y-%m-%d %H:%M:%S %z') }}
 file = {{ log_stream.path }}
-log_stream_name = {{ log_stream.path }}
+log_stream_name = {{ log_stream.stream|default(log_stream.path) }}
 log_group_name = {{ log_stream.group_name | default(log_group_name) }}
 {% endfor %}


### PR DESCRIPTION
Allows customizing the log stream name:

```
    watched_logs:
    - path: /var/log/messages
    - path: /var/log/secure
    - path: /var/log/application.log
      stream: different-application-log-stream-name
```