### PR TITLE
Allow ASG retries when to avoid the AWS rate limit error

### DIFF
--- a/aws-deploy/tasks/main.yml
+++ b/aws-deploy/tasks/main.yml
@@ -28,3 +28,6 @@
     vpc_zone_identifier: "{{ app_subnets | default(None) or omit }}"
     wait_timeout: "{{ wait_timeout | default(480) }}"
   register: asg_result
+  until: asg_result|success
+  retries: 10
+  delay: 10


### PR DESCRIPTION
With CI and UAT + Dev environment, we are beginning to run into the `AWS Rate Limit` error during the ASG Rolling Deploy stage. 

Kenneth Koski has suggested to add a retry stage to hide the problem. That's the solution that the VA team uses.