### PR TITLE
Run app role as root

### DIFF
--- a/deploy-to-aws.yml
+++ b/deploy-to-aws.yml
@@ -65,6 +65,8 @@
 
   roles:
     - role: "{{ app_config[app_name].ansible_role_name }}"
+      become: true
+      become_user: root
       is_aws: true
       region: "{{ aws_config[deploy_env].region }}"
 


### PR DESCRIPTION
This saves role from having to specify `become_user: root` on all its tasks or meta prerequisite roles. 