### PR TITLE
Allow build instance AMI role to be specified

### DIFF
--- a/deploy-to-aws.yml
+++ b/deploy-to-aws.yml
@@ -55,6 +55,7 @@
       user_data: "{{ launch_user_init_script | default(None) or omit }}"
       ami_user: "{{ launch_user | default(None) or omit }}"
       instance_name: "{{ app_group }}-{{ app_project }}-{{ app_name }}-{{ deploy_env }}_ami-{{ timestamp }}"
+      instance_role: "{{ aws_config[deploy_env].ami_instance_role | default(None) or omit }}"
 
 - name: deploy application to new instance
   hosts: tmp_ami_group


### PR DESCRIPTION
So that the build instance can e.g., grab artifacts from private S3 buckets