### PR TITLE
Specify create=True for lineinfile

### DIFF
--- a/centos/tasks/main.yml
+++ b/centos/tasks/main.yml
@@ -29,7 +29,7 @@
   when: skip_update is undefined
 
 - name: configure yum-cron to automatically apply updates.
-  lineinfile: dest=/etc/yum/yum-cron.conf regexp=apply_updates line='apply_updates = yes'
+  lineinfile: create=True dest=/etc/yum/yum-cron.conf regexp=apply_updates line='apply_updates = yes'
 
 - name: start yum-cron
   service:

--- a/centos/tasks/main.yml
+++ b/centos/tasks/main.yml
@@ -30,6 +30,7 @@
 
 - name: configure yum-cron to automatically apply updates.
   lineinfile: create=True dest=/etc/yum/yum-cron.conf regexp=apply_updates line='apply_updates = yes'
+  when: skip_update is undefined
 
 - name: start yum-cron
   service:


### PR DESCRIPTION
* a6d9e55801228f72e71705dd714b48f17ff5ea3d is the same as #34 -- makes the task more robust to failure when targeting Vagrant `bento/centos-6.7` image.
* 6c9c2c62fc42e5b23aa61ceb3bfafa2c9e6d9a44 should have been left in with #33. If we're skipping updates (to speed up tests), yum-cron shouldn't be configured to apply them.
