### PR TITLE
Make it possible to call application-specific roles more than once

### DIFF
--- a/aws-logs/defaults/main.yml
+++ b/aws-logs/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 watched_logs:
   - path: /var/log/messages
+
+region: us-west-1

--- a/aws-logs/defaults/main.yml
+++ b/aws-logs/defaults/main.yml
@@ -1,5 +1,3 @@
 ---
 watched_logs:
   - path: /var/log/messages
-
-log_group_name: "{{ name }}"

--- a/aws-logs/meta/main.yml
+++ b/aws-logs/meta/main.yml
@@ -1,0 +1,1 @@
+allow_duplicates: True

--- a/aws-logs/tasks/main.yml
+++ b/aws-logs/tasks/main.yml
@@ -5,10 +5,19 @@
   service: name=awslogs enabled=true
 
 - name: configure aws (region, cwlogs)
-  template: src=templates/awscli.conf dest=/etc/awslogs/awscli.conf mode=go=r,u=rw
+  template:
+    src: templates/awscli.conf
+    dest: /etc/awslogs/awscli.conf
+    mode: go=r,u=rw
 
 - name: configure awslogs general section
-  template: src=templates/awslogs.conf dest=/etc/awslogs/awslogs.conf mode=go=r,u=rw
+  template:
+    src: templates/awslogs.conf
+    dest: /etc/awslogs/awslogs.conf
+    mode: go=r,u=rw
 
 - name: configure application log streams
-  template: src=templates/app-logs.conf dest=/var/awslogs/etc/config/{{ log_group_name }}.conf mode=go=r,u=rw
+  template:
+    src: templates/app-logs.conf
+    dest: /var/awslogs/etc/config/{{ log_group_name }}.conf
+    mode: go=r,u=rw

--- a/aws-logs/tasks/main.yml
+++ b/aws-logs/tasks/main.yml
@@ -4,8 +4,11 @@
 - name: enable awslogs on boot
   service: name=awslogs enabled=true
 
-- name: configure awslogs
+- name: configure aws (region, cwlogs)
   template: src=templates/awscli.conf dest=/etc/awslogs/awscli.conf mode=go=r,u=rw
 
-- name: configure watched log files
+- name: configure awslogs general section
   template: src=templates/awslogs.conf dest=/etc/awslogs/awslogs.conf mode=go=r,u=rw
+
+- name: configure application log streams
+  template: src=templates/app-logs.conf dest=/var/awslogs/etc/config/{{ log_group_name }}.conf mode=go=r,u=rw

--- a/aws-logs/tasks/main.yml
+++ b/aws-logs/tasks/main.yml
@@ -3,30 +3,17 @@
     url: https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
     dest: /tmp/awslogs-agent-setup.py
 
-- name: write config file
+- name: write config file for installation
   template:
     src: templates/awslogs.conf
-    dest: /etc/awslogs/awslogs.conf
+    dest: /tmp/awslogs.conf
     mode: go=r,u=rw
 
 - name: install
-  shell: "/usr/bin/python /tmp/awslogs-agent-setup.py --non-interactive --region {{ region }} --configfile /etc/awslogs/awslogs.conf"
+  shell: "/usr/bin/python /tmp/awslogs-agent-setup.py --non-interactive --region {{ region }} --configfile /tmp/awslogs.conf"
 
 - name: enable awslogs on boot
   service: name=awslogs enabled=true
-
-- name: configure aws (region, cwlogs)
-  template:
-    src: templates/awscli.conf
-    dest: /etc/awslogs/awscli.conf
-    mode: go=r,u=rw
-
-- name: create dir
-  file:
-    path: /var/awslogs/etc/config/
-    state: directory
-    recurse: yes
-  when: watched_logs is defined and watched_logs|length > 0
 
 - name: configure application log streams
   template:

--- a/aws-logs/tasks/main.yml
+++ b/aws-logs/tasks/main.yml
@@ -16,8 +16,16 @@
     dest: /etc/awslogs/awslogs.conf
     mode: go=r,u=rw
 
+- name: create dir
+  file:
+    path: /var/awslogs/etc/config/
+    state: directory
+    recurse: yes
+  when: watched_logs is defined and watch_logs|length > 0
+
 - name: configure application log streams
   template:
     src: templates/app-logs.conf
     dest: /var/awslogs/etc/config/{{ log_group_name }}.conf
     mode: go=r,u=rw
+  when: watched_logs is defined and watch_logs|length > 0

--- a/aws-logs/tasks/main.yml
+++ b/aws-logs/tasks/main.yml
@@ -3,6 +3,12 @@
     url: https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
     dest: /tmp/awslogs-agent-setup.py
 
+- name: write config file
+  template:
+    src: templates/awslogs.conf
+    dest: /etc/awslogs/awslogs.conf
+    mode: go=r,u=rw
+
 - name: install
   shell: "/usr/bin/python /tmp/awslogs-agent-setup.py --non-interactive --region {{ region }} --configfile /etc/awslogs/awslogs.conf"
 
@@ -13,12 +19,6 @@
   template:
     src: templates/awscli.conf
     dest: /etc/awslogs/awscli.conf
-    mode: go=r,u=rw
-
-- name: configure awslogs general section
-  template:
-    src: templates/awslogs.conf
-    dest: /etc/awslogs/awslogs.conf
     mode: go=r,u=rw
 
 - name: create dir

--- a/aws-logs/tasks/main.yml
+++ b/aws-logs/tasks/main.yml
@@ -21,11 +21,11 @@
     path: /var/awslogs/etc/config/
     state: directory
     recurse: yes
-  when: watched_logs is defined and watch_logs|length > 0
+  when: watched_logs is defined and watched_logs|length > 0
 
 - name: configure application log streams
   template:
     src: templates/app-logs.conf
     dest: /var/awslogs/etc/config/{{ log_group_name }}.conf
     mode: go=r,u=rw
-  when: watched_logs is defined and watch_logs|length > 0
+  when: watched_logs is defined and watched_logs|length > 0

--- a/aws-logs/tasks/main.yml
+++ b/aws-logs/tasks/main.yml
@@ -1,5 +1,10 @@
-- name: install awslogs agent
-  yum: name=awslogs state=latest
+- name: download awslogs agent installer
+  get_url:
+    url: https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
+    dest: /tmp/awslogs-agent-setup.py
+
+- name: install
+  shell: "/usr/bin/python /tmp/awslogs-agent-setup.py --non-interactive --region {{ region }} --configfile /etc/awslogs/awslogs.conf"
 
 - name: enable awslogs on boot
   service: name=awslogs enabled=true

--- a/aws-logs/templates/app-logs.conf
+++ b/aws-logs/templates/app-logs.conf
@@ -1,0 +1,8 @@
+{% for log_stream in watched_logs %}
+
+[{{ log_stream.path }}]
+datetime_format = {{ log_stream.datetime_format|default('%Y-%m-%d %H:%M:%S %z') }}
+file = {{ log_stream.path }}
+log_stream_name = {{ log_stream.stream|default(log_stream.path) }}
+log_group_name = {{ log_stream.group_name | default(log_group_name) }}
+{% endfor %}

--- a/aws-logs/templates/awscli.conf
+++ b/aws-logs/templates/awscli.conf
@@ -1,4 +1,0 @@
-[plugins]
-cwlogs = cwlogs
-[default]
-region = {{ region }}

--- a/aws-logs/templates/awscli.conf
+++ b/aws-logs/templates/awscli.conf
@@ -1,4 +1,4 @@
 [plugins]
 cwlogs = cwlogs
 [default]
-region = {{ region | default ('us-east-1') }}
+region = {{ region }}

--- a/aws-logs/templates/awslogs.conf
+++ b/aws-logs/templates/awslogs.conf
@@ -2,12 +2,3 @@
 # Path to the CloudWatch Logs agent's state file. The agent uses this file to maintain
 # client side state across its executions.
 state_file = /var/lib/awslogs/agent-state
-
-{% for log_stream in watched_logs %}
-
-[{{ log_stream.path }}]
-datetime_format = {{ log_stream.datetime_format|default('%Y-%m-%d %H:%M:%S %z') }}
-file = {{ log_stream.path }}
-log_stream_name = {{ log_stream.stream|default(log_stream.path) }}
-log_group_name = {{ log_stream.group_name | default(log_group_name) }}
-{% endfor %}

--- a/aws-logs/templates/awslogs.conf
+++ b/aws-logs/templates/awslogs.conf
@@ -1,4 +1,4 @@
 [general]
 # Path to the CloudWatch Logs agent's state file. The agent uses this file to maintain
 # client side state across its executions.
-state_file = /var/lib/awslogs/agent-state
+state_file = /var/awslogs/agent-state

--- a/logrotate/meta/main.yml
+++ b/logrotate/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+allow_duplicates: True
 galaxy_info:
   author: Nick Hammond
   description: Role to configure logrotate scripts

--- a/nodejs-version-lookup/meta/main.yml
+++ b/nodejs-version-lookup/meta/main.yml
@@ -1,0 +1,1 @@
+allow_duplicates: True

--- a/nodejs/meta/main.yml
+++ b/nodejs/meta/main.yml
@@ -1,0 +1,1 @@
+allow_duplicates: True

--- a/process/meta/main.yml
+++ b/process/meta/main.yml
@@ -1,0 +1,1 @@
+allow_duplicates: True

--- a/rails-build/meta/main.yml
+++ b/rails-build/meta/main.yml
@@ -1,0 +1,1 @@
+allow_duplicates: True

--- a/roadrunner-aws/defaults/main.yml
+++ b/roadrunner-aws/defaults/main.yml
@@ -1,3 +1,5 @@
+log_group_name: "{{ name }}"
+
 default_watched_logs:
   - path: /var/log/messages
     datetime_format: "%b %d %H:%M:%S"

--- a/roadrunner-aws/meta/main.yml
+++ b/roadrunner-aws/meta/main.yml
@@ -3,3 +3,4 @@ allow_duplicates: True
 dependencies:
   - role: aws-logs
     watched_logs: "{{ default_watched_logs | union(additional_watched_logs | default([])) }}"
+    log_group_name: "{{ name }}"

--- a/roadrunner-aws/meta/main.yml
+++ b/roadrunner-aws/meta/main.yml
@@ -3,4 +3,3 @@ allow_duplicates: True
 dependencies:
   - role: aws-logs
     watched_logs: "{{ default_watched_logs | union(additional_watched_logs | default([])) }}"
-    log_group_name: "{{ name }}"

--- a/roadrunner-aws/meta/main.yml
+++ b/roadrunner-aws/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+allow_duplicates: True
 dependencies:
   - role: aws-logs
     watched_logs: "{{ default_watched_logs | union(additional_watched_logs | default([])) }}"

--- a/roadrunner/meta/main.yml
+++ b/roadrunner/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+allow_duplicates: True
 dependencies:
   - role: centos
 

--- a/ruby-existence-check/meta/main.yml
+++ b/ruby-existence-check/meta/main.yml
@@ -1,0 +1,1 @@
+allow_duplicates: True

--- a/ruby-version-lookup/meta/main.yml
+++ b/ruby-version-lookup/meta/main.yml
@@ -1,0 +1,1 @@
+allow_duplicates: True

--- a/ruby/meta/main.yml
+++ b/ruby/meta/main.yml
@@ -1,0 +1,1 @@
+allow_duplicates: True


### PR DESCRIPTION
#### Changes to `aws-logs` role
* Install latest `awslogs` agent via script instead of yum package. This has a few advantages:
  - Allows for separate files for each application's awslogs configuration (goal of this PR)
  - Allows for testing on other Linux distros (like Vagrant centos 6).
* Removes dependency on `name` variable in `aws-logs` role and instead makes `log_group_name` an explicit parameter (fixes #43).

#### Changes to other roles
* Set `allow_duplicates: True` where appropriate so that two applications can be installed on the same target host (e.g., a `worker` app and an `http` app can both be combined into a single `staging-server` role).

Fixes #40 