### PR TITLE
Allow public SSH keys to be passed as key contents, not just directories

### DIFF
--- a/authorized-user/tasks/main.yml
+++ b/authorized-user/tasks/main.yml
@@ -9,6 +9,10 @@
   authorized_key: user={{ user }} key={{ public_key }}
   when: public_key is defined
 
-- name: add multiple authorized ssh keys (optional)
+- name: add multiple authorized ssh keys via glob (optional)
   authorized_key: user={{ user }} key={{ lookup('file', item) }}
   with_fileglob: "{{ public_keys_glob | default([]) }}"
+
+- name: add multiple authorized ssh keys via list public keys (optional)
+  authorized_key: user={{ user }} key={{ item }}
+  with_items: "{{ public_keys | default([]) }}"

--- a/aws-launch-user/tasks/main.yml
+++ b/aws-launch-user/tasks/main.yml
@@ -10,11 +10,19 @@
   local_action: command mktemp /tmp/launch-user-ssh-keys.XXXXXXXX
   register: tmp_ssh_keys
 
-- name: Populate concatenated keys file
+- name: Populate concatenated keys file from directory contents
   local_action:
     module: assemble
     src: "{{ keys_directory }}"
     dest: "{{ tmp_ssh_keys.stdout }}"
+  when: keys_directory is defined
+
+- name: Populate concatenated keys file from variable contents
+  local_action:
+    module: copy
+    content: "{{ keys_contents }}"
+    dest: "{{ tmp_ssh_keys.stdout }}"
+  when: keys_contents is defined
 
 - name: Export keys variable
   set_fact:


### PR DESCRIPTION
* Allow `authorized-user` to accept a list of `public_keys` contents instead of just a directory that contains public key files. 
* Allow ` aws-launch-user` to accept fully assembled (concatenated) `keys_contents` instead of just a directory that contains public key files.

Both of these introduce more control over which SSH keys are specified. 