### PR TITLE
Add task for defining npm registry server

### DIFF
--- a/nodejs/defaults/main.yml
+++ b/nodejs/defaults/main.yml
@@ -1,3 +1,13 @@
 # fallback placeholder. This is determined by the corresponding npm used by
 # the specific version of nodejs.
 npm_version: 2.14.4
+
+# This is an instance we run within the VPC to cache
+# # npm modules using sinopia
+npm_server: {
+  dev: "http://172.30.67.236:3000",
+  uat: "http://172.30.67.236:3000",
+  prod: "https://registry.npmjs.org/"
+}
+
+npm_registry_url: "{{ npm_server[deploy_env] }}"

--- a/nodejs/tasks/main.yml
+++ b/nodejs/tasks/main.yml
@@ -56,6 +56,9 @@
   shell: npm i -g npm@{{ npm_version }}
   when: nodejs_preinstalled == false
 
+- name: set npm registry
+  shell: npm set registry {{ npm_registry_url }}
+
 # Run NPM install to download all the NPM packages and webpack to run the
 # babel precompiler.
 - name: npm install


### PR DESCRIPTION
This sets the npm registry to our npm cache server

connects https://github.com/department-of-veterans-affairs/appeals-deployment/issues/226

Testing:
- Manually ssh'd to demo instance, set registry, did an npm install sucessfully
- Ran this ansible task locally with `deploy_env=uat`, verified npm registry url:
<img width="331" alt="screen shot 2017-01-04 at 5 39 35 pm" src="https://cloud.githubusercontent.com/assets/2256237/21661932/c61d3f1e-d2a4-11e6-8761-8752a28b998e.png">
