### PR TITLE
Clear authorized_keys before adding specified keys

### DIFF
--- a/authorized-user/tasks/main.yml
+++ b/authorized-user/tasks/main.yml
@@ -4,6 +4,11 @@
 - name: make {{ user }} sudo
   template: src=sudoers dest=/etc/sudoers.d/{{ user }} owner=root group=root mode=0440 validate='visudo -cf %s'
   when: sudoer
+  
+- name: clear any previous authorized keys
+  file:
+    path: /home/{{ user }}/.ssh/authorized_keys
+    state: absent
 
 - name: add a single authorized ssh key (optional)
   authorized_key: user={{ user }} key={{ public_key }}

--- a/authorized-user/tasks/main.yml
+++ b/authorized-user/tasks/main.yml
@@ -4,20 +4,13 @@
 - name: make {{ user }} sudo
   template: src=sudoers dest=/etc/sudoers.d/{{ user }} owner=root group=root mode=0440 validate='visudo -cf %s'
   when: sudoer
-  
-- name: clear any previous authorized keys
-  file:
-    path: /home/{{ user }}/.ssh/authorized_keys
-    state: absent
 
 - name: add a single authorized ssh key (optional)
-  authorized_key: user={{ user }} key={{ public_key }}
+  authorized_key: user={{ user }} key={{ public_key }} exclusive=True
   when: public_key is defined
 
-- name: add multiple authorized ssh keys via glob (optional)
-  authorized_key: user={{ user }} key={{ lookup('file', item) }}
-  with_fileglob: "{{ public_keys_glob | default([]) }}"
-
 - name: add multiple authorized ssh keys via list public keys (optional)
-  authorized_key: user={{ user }} key={{ item }}
-  with_items: "{{ public_keys | default([]) }}"
+  copy:
+    content: "{{ public_keys | join('\n') }}"
+    dest: /home/{{ user }}/.ssh/authorized_keys
+  when: public_keys is defined


### PR DESCRIPTION
Otherwise this role cannot be run to revoke keys on existing instances--the new keys are just appended to the `/home/{{ used }}/.ssh/authorized_keys`.

* If a single key is passed in via `public_key`, use ansible `authorized_key` module w/ the `exclusive` option
* If a list of keys is passed in via `public_keys`, join with newline and copy to `/home/{{ user }}/authorized_keys`
* Remove the unused `public_keys_glob` option.