### PR TITLE
don't overwrite default process stdout redirect

### DIFF
--- a/rails-build/templates/puma.rb
+++ b/rails-build/templates/puma.rb
@@ -6,8 +6,6 @@ pidfile '{{app_src}}/tmp/pids/puma.pid'
 
 state_path '{{app_src}}/tmp/pids/puma.state'
 
-stdout_redirect '{{app_src}}/log/{{ name }}.out', '{{app_src}}/log/{{ name }}.out'
-
 threads {{min_threads}}, {{max_threads}}
 
 {% if num_workers > 1 %}


### PR DESCRIPTION
This will overwrite the [process default stdout redirect](https://github.com/department-of-veterans-affairs/ansible-common-roles/blob/puma-stdout/process/defaults/main.yml#L3) and cause the file to be truncated after each restart, which is not the intended behavior.