### PR TITLE
Allow a wait time to be specified before upstart script runs the process

### DIFF
--- a/process/defaults/main.yml
+++ b/process/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
 # TODO(awong): This is misnamed as it redirects both stdout and stderr.
 stdout_redirect: "{{ app_home }}/{{ name }}.out"
+
+# Zero wait time (sec) by default.
+wait_time_before_start: "0"
 ...

--- a/process/templates/upstart.conf
+++ b/process/templates/upstart.conf
@@ -12,6 +12,9 @@ kill timeout 20
 
 script
 
+    # if the application requires any wait time, sleep here
+    sleep "{{ wait_time_before_start }}"
+
     # execute command as user via exec (twice) to stay in same process (otherwise
     # upstart can't track it); $0 is the command to execute and $@ are its
     # parameters; the double-dash -- tells su to stop parsing command line


### PR DESCRIPTION
This PR provides an escape hatch for bug https://github.com/department-of-veterans-affairs/appeals-deployment/issues/156.

While we don't fully understand the root cause, we know if we delay the startup of the application, it hides the problem.