### PR TITLE
Update upstart.conf to await the cloud-final event in aws environment

### DIFF
--- a/process/templates/upstart.conf
+++ b/process/templates/upstart.conf
@@ -1,6 +1,6 @@
 description "init script for {{ name }}"
 
-start on runlevel [2345]{% if is_aws is defined %} and started cloud-init{% endif %}
+start on runlevel [2345]{% if is_aws is defined %} and started cloud-final{% endif %}
 
 stop on runlevel [016]
 


### PR DESCRIPTION
This PR has no impact on our applications. But if we ever use [ec2 user data](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html), waiting for cloud-final instead of cloud-init ensures the user-data init-script will run before the upstart scripts. 